### PR TITLE
feat: provide source dimensions if available

### DIFF
--- a/src/builders.ts
+++ b/src/builders.ts
@@ -2,7 +2,6 @@ import { FixedObject, FluidObject } from 'gatsby-image'
 import * as A from 'fp-ts/lib/Array'
 import * as O from 'fp-ts/lib/Option'
 import * as R from 'fp-ts/lib/Record'
-import { Option } from 'fp-ts/lib/Option'
 import { eqNumber } from 'fp-ts/lib/Eq'
 import { ordNumber } from 'fp-ts/lib/Ord'
 import { pipe } from 'fp-ts/lib/pipeable'
@@ -27,7 +26,7 @@ const FLUID_BREAKPOINT_FACTORS = [0.25, 0.5, 1.5, 2]
 // Default params for placeholder images.
 const DEFAULT_LQIP_PARAMS: ImgixUrlParams = { w: 100, blur: 15, q: 20 }
 
-export const buildImgixUrl = (url: string, secureUrlToken: Option<string>) => (
+export const buildImgixUrl = (url: string, secureUrlToken?: string) => (
   params: ImgixUrlParams,
 ): string =>
   pipe(
@@ -38,10 +37,10 @@ export const buildImgixUrl = (url: string, secureUrlToken: Option<string>) => (
       param === undefined ? O.some(undefined) : O.some(String(param)),
     ),
     setURLSearchParams(url),
-    signURL(secureUrlToken),
+    signURL(O.fromNullable(secureUrlToken)),
   )
 
-const buildImgixLqipUrl = (url: string, secureUrlToken: Option<string>) => (
+const buildImgixLqipUrl = (url: string, secureUrlToken?: string) => (
   params: ImgixUrlParams,
 ): string =>
   pipe(
@@ -49,10 +48,9 @@ const buildImgixLqipUrl = (url: string, secureUrlToken: Option<string>) => (
     buildImgixUrl(url, secureUrlToken),
   )
 
-const buildImgixFixedSrcSet = (
-  baseUrl: string,
-  secureUrlToken: Option<string>,
-) => (params: ImgixUrlParams): string =>
+const buildImgixFixedSrcSet = (baseUrl: string, secureUrlToken?: string) => (
+  params: ImgixUrlParams,
+): string =>
   pipe(
     FIXED_RESOLUTIONS,
     A.map((dpr) =>
@@ -82,11 +80,9 @@ export const buildImgixFixed = ({
   url,
   sourceWidth,
   sourceHeight,
-  secureUrlToken: rawSecureUrlToken,
+  secureUrlToken,
   args = {},
 }: BuildImgixFixedArgs): FixedObject => {
-  const secureUrlToken = O.fromNullable(rawSecureUrlToken)
-
   const aspectRatio = sourceWidth / sourceHeight
 
   let width: number
@@ -149,10 +145,9 @@ type BuildFluidSrcSetArgs = {
   srcSetBreakpoints?: number[]
 }
 
-const buildImgixFluidSrcSet = (
-  baseUrl: string,
-  secureUrlToken: Option<string>,
-) => (params: ImgixUrlParams) => ({
+const buildImgixFluidSrcSet = (baseUrl: string, secureUrlToken?: string) => (
+  params: ImgixUrlParams,
+) => ({
   aspectRatio,
   maxWidth,
   srcSetBreakpoints = FLUID_BREAKPOINT_FACTORS.map((x) => maxWidth * x),
@@ -191,11 +186,9 @@ export const buildImgixFluid = ({
   url,
   sourceWidth,
   sourceHeight,
-  secureUrlToken: rawSecureUrlToken,
+  secureUrlToken,
   args = {},
 }: BuildImgixFluidArgs): FluidObject => {
-  const secureUrlToken = O.fromNullable(rawSecureUrlToken)
-
   const aspectRatio = sourceWidth / sourceHeight
   const maxWidth = args.maxWidth ?? DEFAULT_FLUID_MAX_WIDTH
 

--- a/src/createImgixBase64FieldConfig.ts
+++ b/src/createImgixBase64FieldConfig.ts
@@ -5,39 +5,32 @@ import {
   GraphQLFieldConfig,
 } from 'gatsby/graphql'
 import { FixedObject, FluidObject } from 'gatsby-image'
-import * as O from 'fp-ts/lib/Option'
 import * as T from 'fp-ts/lib/Task'
 import * as TE from 'fp-ts/lib/TaskEither'
 import { pipe } from 'fp-ts/lib/pipeable'
 
-import { fetchImgixBase64Url, ImgixResolveUrl } from './shared'
-import { taskEitherFromUrlResolver } from './utils'
+import { fetchImgixBase64Url, ImgixSourceDataResolver } from './shared'
+import { taskEitherFromSourceDataResolver } from './utils'
 
 interface CreateImgixBase64UrlFieldConfigArgs {
-  resolveUrl?: ImgixResolveUrl<FixedObject | FluidObject>
-  secureUrlToken?: string
+  resolveUrl?: ImgixSourceDataResolver<FixedObject | FluidObject, string>
   cache: GatsbyCache
 }
 
 export const createImgixBase64UrlFieldConfig = <TContext>({
   resolveUrl = (obj: FixedObject | FluidObject): string | null | undefined =>
     obj.base64,
-  secureUrlToken: rawSecureUrlToken,
   cache,
 }: CreateImgixBase64UrlFieldConfigArgs): GraphQLFieldConfig<
   FixedObject | FluidObject,
   TContext
-> => {
-  const secureUrlToken = O.fromNullable(rawSecureUrlToken)
-
-  return {
-    type: new GraphQLNonNull(GraphQLString),
-    resolve: (obj: FixedObject | FluidObject): Promise<string | undefined> =>
-      pipe(
-        obj,
-        taskEitherFromUrlResolver(resolveUrl),
-        TE.chain(fetchImgixBase64Url(cache, secureUrlToken)),
-        TE.fold(() => T.of(undefined), T.of),
-      )(),
-  }
-}
+> => ({
+  type: new GraphQLNonNull(GraphQLString),
+  resolve: (obj: FixedObject | FluidObject): Promise<string | undefined> =>
+    pipe(
+      obj,
+      taskEitherFromSourceDataResolver(resolveUrl),
+      TE.chain(fetchImgixBase64Url(cache)),
+      TE.fold(() => T.of(undefined), T.of),
+    )(),
+})

--- a/src/createImgixFluidFieldConfig.ts
+++ b/src/createImgixFluidFieldConfig.ts
@@ -10,7 +10,6 @@ import {
 } from 'gatsby/graphql'
 import { FluidObject } from 'gatsby-image'
 import { ComposeFieldConfigAsObject } from 'graphql-compose'
-import * as O from 'fp-ts/lib/Option'
 import * as T from 'fp-ts/lib/Task'
 import * as TE from 'fp-ts/lib/TaskEither'
 import { pipe } from 'fp-ts/lib/pipeable'
@@ -19,27 +18,25 @@ import { ImgixFluidArgs, ImgixUrlParams } from './types'
 import { createImgixBase64UrlFieldConfig } from './createImgixBase64FieldConfig'
 import { buildImgixFluid, DEFAULT_FLUID_MAX_WIDTH } from './builders'
 import {
-  ImgixResolveUrl,
+  ImgixSourceDataResolver,
   ImgixUrlParamsInputType,
-  fetchImgixMetadata,
+  resolveDimensions,
 } from './shared'
-import { taskEitherFromUrlResolver } from './utils'
+import { taskEitherFromSourceDataResolver, noop } from './utils'
 
 interface CreateImgixFluidTypeArgs {
   name: string
   cache: GatsbyCache
-  secureUrlToken?: string
 }
 
 export const createImgixFluidType = ({
   name,
   cache,
-  secureUrlToken,
 }: CreateImgixFluidTypeArgs): GraphQLObjectType<FluidObject> =>
   new GraphQLObjectType({
     name,
     fields: {
-      base64: createImgixBase64UrlFieldConfig({ cache, secureUrlToken }),
+      base64: createImgixBase64UrlFieldConfig({ cache }),
       src: { type: new GraphQLNonNull(GraphQLString) },
       srcSet: { type: new GraphQLNonNull(GraphQLString) },
       srcWebp: { type: new GraphQLNonNull(GraphQLString) },
@@ -51,7 +48,9 @@ export const createImgixFluidType = ({
 
 interface CreateImgixFluidFieldConfigArgs<TSource> {
   type: GraphQLObjectType<FluidObject>
-  resolveUrl: ImgixResolveUrl<TSource>
+  resolveUrl: ImgixSourceDataResolver<TSource, string>
+  resolveWidth?: ImgixSourceDataResolver<TSource, number>
+  resolveHeight?: ImgixSourceDataResolver<TSource, number>
   secureUrlToken?: string
   cache: GatsbyCache
   defaultImgixParams?: ImgixUrlParams
@@ -61,7 +60,9 @@ interface CreateImgixFluidFieldConfigArgs<TSource> {
 export const createImgixFluidFieldConfig = <TSource, TContext>({
   type,
   resolveUrl,
-  secureUrlToken: rawSecureUrlToken,
+  resolveWidth = noop,
+  resolveHeight = noop,
+  secureUrlToken,
   cache,
   defaultImgixParams,
   defaultPlaceholderImgixParams,
@@ -69,67 +70,72 @@ export const createImgixFluidFieldConfig = <TSource, TContext>({
   TSource,
   TContext,
   ImgixFluidArgs
-> => {
-  const secureUrlToken = O.fromNullable(rawSecureUrlToken)
-
-  return {
-    type,
-    args: {
-      maxWidth: {
-        type: GraphQLInt,
-        defaultValue: DEFAULT_FLUID_MAX_WIDTH,
-      },
-      maxHeight: {
-        type: GraphQLInt,
-      },
-      srcSetBreakpoints: {
-        type: new GraphQLList(GraphQLInt),
-      },
-      imgixParams: {
-        type: ImgixUrlParamsInputType,
-        defaultValue: {},
-      },
-      placeholderImgixParams: {
-        type: ImgixUrlParamsInputType,
-        defaultValue: {},
-      },
+> => ({
+  type,
+  args: {
+    maxWidth: {
+      type: GraphQLInt,
+      defaultValue: DEFAULT_FLUID_MAX_WIDTH,
     },
-    resolve: (
-      obj: TSource,
-      args: ImgixFluidArgs,
-    ): Promise<FluidObject | undefined> =>
-      pipe(
-        obj,
-        taskEitherFromUrlResolver(resolveUrl),
-        TE.chain((url) =>
-          pipe(
-            url,
-            fetchImgixMetadata(cache, secureUrlToken),
-            TE.map((metadata) =>
-              buildImgixFluid({
-                url,
-                sourceWidth: metadata.PixelWidth,
-                sourceHeight: metadata.PixelHeight,
-                secureUrlToken: rawSecureUrlToken,
-                args: {
-                  ...args,
-                  imgixParams: {
-                    ...defaultImgixParams,
-                    ...args.imgixParams,
-                  },
-                  placeholderImgixParams: {
-                    ...defaultPlaceholderImgixParams,
-                    ...args.placeholderImgixParams,
-                  },
+    maxHeight: {
+      type: GraphQLInt,
+    },
+    srcSetBreakpoints: {
+      type: new GraphQLList(GraphQLInt),
+    },
+    imgixParams: {
+      type: ImgixUrlParamsInputType,
+      defaultValue: {},
+    },
+    placeholderImgixParams: {
+      type: ImgixUrlParamsInputType,
+      defaultValue: {},
+    },
+  },
+  resolve: (
+    obj: TSource,
+    args: ImgixFluidArgs,
+  ): Promise<FluidObject | undefined> =>
+    pipe(
+      obj,
+      taskEitherFromSourceDataResolver(
+        resolveUrl,
+        (url) => typeof url === 'string',
+      ),
+      TE.chain((url) =>
+        pipe(
+          url,
+          resolveDimensions(
+            obj,
+            resolveWidth,
+            resolveHeight,
+            cache,
+            secureUrlToken,
+          ),
+          TE.map(([width, height]) =>
+            buildImgixFluid({
+              url,
+              sourceWidth: width,
+              sourceHeight: height,
+              secureUrlToken,
+              args: {
+                ...args,
+                imgixParams: {
+                  ...defaultImgixParams,
+                  ...args.imgixParams,
                 },
-              }),
-            ),
+                placeholderImgixParams: {
+                  ...defaultPlaceholderImgixParams,
+                  ...args.placeholderImgixParams,
+                },
+              },
+            }),
           ),
         ),
-        TE.fold(() => T.of(undefined), T.of),
-      )(),
-  }
-}
+      ),
+      TE.getOrElseW(() => T.of(undefined)),
+    )(),
+})
 
 export const createImgixFluidSchemaFieldConfig = <TSource, TContext>(
   args: CreateImgixFluidFieldConfigArgs<TSource>,

--- a/src/createImgixUrlFieldConfig.ts
+++ b/src/createImgixUrlFieldConfig.ts
@@ -1,61 +1,59 @@
 import { GraphQLFieldConfig, GraphQLString } from 'gatsby/graphql'
 import { ComposeFieldConfigAsObject } from 'graphql-compose'
-import * as O from 'fp-ts/lib/Option'
 import * as T from 'fp-ts/lib/Task'
 import * as TE from 'fp-ts/lib/TaskEither'
 import { pipe } from 'fp-ts/lib/pipeable'
 
 import { buildImgixUrl } from './builders'
-import { ImgixResolveUrl, ImgixUrlParamsInputType } from './shared'
+import { ImgixSourceDataResolver, ImgixUrlParamsInputType } from './shared'
 import { ImgixUrlParams } from './types'
-import { taskEitherFromUrlResolver, semigroupImgixUrlParams } from './utils'
+import {
+  taskEitherFromSourceDataResolver,
+  semigroupImgixUrlParams,
+} from './utils'
 
 export interface ImgixUrlArgs {
   imgixParams?: ImgixUrlParams
 }
 
 interface CreateImgixUrlFieldConfigArgs<TSource> {
-  resolveUrl: ImgixResolveUrl<TSource>
+  resolveUrl: ImgixSourceDataResolver<TSource, string>
   secureUrlToken?: string
   defaultImgixParams?: ImgixUrlParams
 }
 
 export const createImgixUrlFieldConfig = <TSource, TContext>({
   resolveUrl,
-  secureUrlToken: rawSecureUrlToken,
+  secureUrlToken,
   defaultImgixParams = {},
 }: CreateImgixUrlFieldConfigArgs<TSource>): GraphQLFieldConfig<
   TSource,
   TContext,
   ImgixUrlArgs
-> => {
-  const secureUrlToken = O.fromNullable(rawSecureUrlToken)
-
-  return {
-    type: GraphQLString,
-    args: {
-      imgixParams: {
-        type: ImgixUrlParamsInputType,
-        defaultValue: {},
-      },
+> => ({
+  type: GraphQLString,
+  args: {
+    imgixParams: {
+      type: ImgixUrlParamsInputType,
+      defaultValue: {},
     },
-    resolve: (obj: TSource, args: ImgixUrlArgs): Promise<string | undefined> =>
-      pipe(
-        obj,
-        taskEitherFromUrlResolver(resolveUrl),
-        TE.map((url) =>
-          pipe(
-            semigroupImgixUrlParams.concat(
-              defaultImgixParams,
-              args.imgixParams ?? {},
-            ),
-            buildImgixUrl(url, secureUrlToken),
+  },
+  resolve: (obj: TSource, args: ImgixUrlArgs): Promise<string | undefined> =>
+    pipe(
+      obj,
+      taskEitherFromSourceDataResolver(resolveUrl),
+      TE.map((url) =>
+        pipe(
+          semigroupImgixUrlParams.concat(
+            defaultImgixParams,
+            args.imgixParams ?? {},
           ),
+          buildImgixUrl(url, secureUrlToken),
         ),
-        TE.fold(() => T.of(undefined), T.of),
-      )(),
-  }
-}
+      ),
+      TE.fold(() => T.of(undefined), T.of),
+    )(),
+})
 
 export const createImgixUrlSchemaFieldConfig = <TSource, TContext>(
   args: CreateImgixUrlFieldConfigArgs<TSource>,


### PR DESCRIPTION
`resolveWidth` and `resolveHeight` are new options on `createImgixFixedFieldConfig` and `createImgixFluidFieldConfig`. Both options should resolve to their respective measurement. If either cannot be resolved using the the provided function, a network request is made
to fetch the data from Imgix.