### PR TITLE
docs: add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-> **This package will soon be replaced by [`@imgix/gatsby`][imgix-gatsby]**
+> **This package has been replaced by [`@imgix/gatsby`][imgix-gatsby]**
 >
-> The official Imgix plugin is based on this repository and includes additional
-> features, such as [gatsby-plugin-image] support. Please migrate to
+> The official Imgix plugin is based on this package and includes additional
+> features such as [gatsby-plugin-image] support. Please migrate to
 > `@imgix/gatsby`.
 >
-> This repository and npm package will be archived and deprecated.
+> This repository and npm package is deprecated.
 
 # gatsby-plugin-imgix
 


### PR DESCRIPTION
`gatsby-plugin-imgix` is ready to be deprecated and replaced fully by `@imgix/gatsby`.

This PR adds a notice to the README to inform users to use the replacement package.

Once this PR is merged, a new patch version of the plugin can be published to update the README. The plugin can then be deprecated on npm. The GitHub repository can also optionally be archived.

```sh
yarn release
npm deprecate gatsby-plugin-imgix "gatsby-plugin-imgix has been replaced by @imgix/gatsby. Please uninstall gatsby-plugin-imgix and replace it with @imgix/gatsby"
```