### PR TITLE
feat: v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.9.1](https://github.com/WalltoWall/gatsby-plugin-imgix/compare/v0.9.1-next.0...v0.9.1) (2021-07-27)
+
 ### [0.9.1-next.0](https://github.com/WalltoWall/gatsby-plugin-imgix/compare/v0.9.0...v0.9.1-next.0) (2021-03-21)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-imgix",
-  "version": "0.9.1-next.0",
+  "version": "0.9.1",
   "description": "Gatsby plugin which enables the use of Imgix to apply image transformations at request-time",
   "license": "BSD-2-Clause",
   "main": "dist/gatsby-plugin-imgix.js",


### PR DESCRIPTION
This just updates the CHANGELOG and `package.json`. `v0.9.1` was published in `angeloashmore/gatsby-plugin-imgix`.